### PR TITLE
Add option address

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Available Commands:
 Flags:
   -c, --critical float   Critical threshold for offset in ms (default 100)
   -w, --warning float    Warning threshold for offset in ms (default 10)
+  -a, --address string   Address to check NTP (default 127.0.0.1:123)
   -h, --help             help for check-ntp
 
 Use "check-ntp [command] --help" for more information about a command.
@@ -75,7 +76,7 @@ spec:
   subscriptions:
   - system
   runtime_assets:
-  - nixwiz/check-ntp
+  - nmollerup/check-ntp
 ```
 
 ## Installation from source
@@ -97,6 +98,6 @@ For more information about contributing to this plugin, see [Contributing][4].
 
 [1]: https://docs.sensu.io/sensu-go/latest/reference/checks/
 [2]: https://docs.sensu.io/sensu-go/latest/reference/assets/
-[3]: https://bonsai.sensu.io/assets/nixwiz/check-ntp
+[3]: https://bonsai.sensu.io/assets/nmollerup/check-ntp
 [4]: https://github.com/sensu/sensu-go/blob/master/CONTRIBUTING.md
 [5]: https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/collect-metrics-with-checks/#supported-output-metric-formats

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ type Config struct {
 	sensu.PluginConfig
 	Warning  float64
 	Critical float64
+	Address  string
 }
 
 var (
@@ -42,6 +43,14 @@ var (
 			Usage:     "Warning threshold for offset in ms",
 			Value:     &plugin.Warning,
 		},
+		&sensu.PluginConfigOption[string]{
+			Path:      "address",
+			Argument:  "address",
+			Shorthand: "a",
+			Default:   "127.0.0.1:123",
+			Usage:     "Address to check NTP",
+			Value:     &plugin.Address,
+		},
 	}
 )
 
@@ -64,7 +73,7 @@ func checkArgs(event *corev2.Event) (int, error) {
 }
 
 func executeCheck(event *corev2.Event) (int, error) {
-	result, err := checker.RunCheck("")
+	result, err := checker.RunCheck(plugin.Address)
 	if err != nil {
 		fmt.Printf("%s CRITICAL: failed to run check, error: %v\n", plugin.PluginConfig.Name, err)
 		return sensu.CheckStateCritical, nil


### PR DESCRIPTION
Add option to specify address to check NTP. Allowing to check remote NTP or ipv4/ipv6.